### PR TITLE
Add ANEOS pyrolite EOS table

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ set by a base type ID (multiplied by 100) plus a minor type:
     + Forsterite (Stewart et al. 2019): `ANEOS_forsterite` : `400`
     + Iron (Stewart, zenodo.org/record/3866507): `ANEOS_iron` : `401`
     + Fe85Si15 (Stewart, zenodo.org/record/3866550): `ANEOS_Fe85Si15` : `402`
+    + Pyrolite ([Stewart 2022](https://github.com/ststewart/aneos-pyrolite-2022)): `ANEOS_pyrolite` : `403`
 + Custom (in SESAME-style tables): ``9``
     + User-provided custom material(s): ``900``, ``901``, ..., ``904``
 

--- a/woma/eos/sesame.py
+++ b/woma/eos/sesame.py
@@ -426,6 +426,33 @@ A2_phase_ANEOS_forsterite = np.zeros((2, 2))
     np.zeros((2, 2)),
     np.zeros((2, 2)),
 )
+(
+    A1_rho_ANEOS_pyrolite,
+    A1_T_ANEOS_pyrolite,
+    A2_u_ANEOS_pyrolite,
+    A2_P_ANEOS_pyrolite,
+    A2_c_ANEOS_pyrolite,
+    A2_s_ANEOS_pyrolite,
+    A1_log_rho_ANEOS_pyrolite,
+    A1_log_T_ANEOS_pyrolite,
+    A2_log_u_ANEOS_pyrolite,
+    A2_log_P_ANEOS_pyrolite,
+    A2_log_c_ANEOS_pyrolite,
+    A2_log_s_ANEOS_pyrolite,
+) = (
+    np.zeros(1),
+    np.zeros(1),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+    np.zeros(1),
+    np.zeros(1),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+    np.zeros((2, 2)),
+)
 
 # AQUA
 (
@@ -767,6 +794,14 @@ def Z_rho_T(rho, T, mat_id, Z_choice):
             A2_Z = A2_u_ANEOS_Fe85Si15
         elif Z_choice == "s":
             A2_Z = A2_s_ANEOS_Fe85Si15
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A1_log_rho, A1_log_T = (A1_log_rho_ANEOS_pyrolite, A1_log_T_ANEOS_pyrolite)
+        if Z_choice == "P":
+            A2_Z = A2_P_ANEOS_pyrolite
+        elif Z_choice == "u":
+            A2_Z = A2_u_ANEOS_pyrolite
+        elif Z_choice == "s":
+            A2_Z = A2_s_ANEOS_pyrolite
     elif mat_id == gv.id_AQUA:
         A1_log_rho, A1_log_T = (A1_log_rho_AQUA, A1_log_T_AQUA)
         if Z_choice == "P":
@@ -1086,6 +1121,24 @@ def Z_rho_Y(rho, Y, mat_id, Z_choice, Y_choice):
             A2_log_Y = A2_log_s_ANEOS_Fe85Si15
         elif Y_choice == "c":
             A2_log_Y = A2_log_c_ANEOS_Fe85Si15
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A1_log_rho = A1_log_rho_ANEOS_pyrolite
+        if Z_choice == "P":
+            A2_Z = A2_P_ANEOS_pyrolite
+        elif Z_choice == "u":
+            A2_Z = A2_u_ANEOS_pyrolite
+        elif Z_choice == "s":
+            A2_Z = A2_s_ANEOS_pyrolite
+        elif Z_choice == "c":
+            A2_Z = A2_c_ANEOS_pyrolite
+        if Y_choice == "P":
+            A2_log_Y = A2_log_P_ANEOS_pyrolite
+        elif Y_choice == "u":
+            A2_log_Y = A2_log_u_ANEOS_pyrolite
+        elif Y_choice == "s":
+            A2_log_Y = A2_log_s_ANEOS_pyrolite
+        elif Y_choice == "c":
+            A2_log_Y = A2_log_c_ANEOS_pyrolite
     elif mat_id == gv.id_AQUA:
         A1_log_rho = A1_log_rho_AQUA
         if Z_choice == "P":
@@ -1508,6 +1561,24 @@ def Z_X_T(X, T, mat_id, Z_choice, X_choice):
             A2_log_X = A2_log_s_ANEOS_Fe85Si15
         elif X_choice == "c":
             A2_log_X = A2_log_c_ANEOS_Fe85Si15
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A1_log_T = A1_log_T_ANEOS_pyrolite
+        if Z_choice == "P":
+            A2_Z = A2_P_ANEOS_pyrolite
+        elif Z_choice == "u":
+            A2_Z = A2_u_ANEOS_pyrolite
+        elif Z_choice == "s":
+            A2_Z = A2_s_ANEOS_pyrolite
+        elif Z_choice == "c":
+            A2_Z = A2_c_ANEOS_pyrolite
+        if X_choice == "P":
+            A2_log_X = A2_log_P_ANEOS_pyrolite
+        elif X_choice == "u":
+            A2_log_X = A2_log_u_ANEOS_pyrolite
+        elif X_choice == "s":
+            A2_log_X = A2_log_s_ANEOS_pyrolite
+        elif X_choice == "c":
+            A2_log_X = A2_log_c_ANEOS_pyrolite
     elif mat_id == gv.id_AQUA:
         A1_log_T = A1_log_T_AQUA
         if Z_choice == "P":
@@ -1824,6 +1895,12 @@ def P_u_rho(u, rho, mat_id):
             A1_log_rho_ANEOS_Fe85Si15,
             A2_log_u_ANEOS_Fe85Si15,
         )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_P, A1_log_rho, A2_log_u = (
+            A2_P_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A2_log_u_ANEOS_pyrolite,
+        )
     elif mat_id == gv.id_AQUA:
         A2_P, A1_log_rho, A2_log_u = (A2_P_AQUA, A1_log_rho_AQUA, A2_log_u_AQUA)
     elif mat_id == gv.id_CMS19_H:
@@ -2015,6 +2092,12 @@ def P_T_rho(T, rho, mat_id):
             A1_log_rho_ANEOS_Fe85Si15,
             A1_log_T_ANEOS_Fe85Si15,
         )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_P, A1_log_rho, A1_log_T = (
+            A2_P_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A1_log_T_ANEOS_pyrolite,
+        )
     elif mat_id == gv.id_AQUA:
         A2_P, A1_log_rho, A1_log_T = (A2_P_AQUA, A1_log_rho_AQUA, A1_log_T_AQUA)
     elif mat_id == gv.id_CMS19_H:
@@ -2179,6 +2262,12 @@ def T_rho_s(rho, s, mat_id):
             A1_log_rho_ANEOS_Fe85Si15,
             A2_s_ANEOS_Fe85Si15,
         )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A1_log_T, A1_log_rho, A2_s = (
+            A1_log_T_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A2_s_ANEOS_pyrolite,
+        )
     elif mat_id == gv.id_AQUA:
         A1_log_T, A1_log_rho, A2_s = (A1_log_T_AQUA, A1_log_rho_AQUA, A2_s_AQUA)
     elif mat_id == gv.id_CMS19_H:
@@ -2331,6 +2420,12 @@ def T_u_rho(u, rho, mat_id):
             A1_log_T_ANEOS_Fe85Si15,
             A1_log_rho_ANEOS_Fe85Si15,
             A2_u_ANEOS_Fe85Si15,
+        )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A1_log_T, A1_log_rho, A2_u = (
+            A1_log_T_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A2_u_ANEOS_pyrolite,
         )
     elif mat_id == gv.id_AQUA:
         A1_log_T, A1_log_rho, A2_u = (A1_log_T_AQUA, A1_log_rho_AQUA, A2_u_AQUA)
@@ -2487,6 +2582,12 @@ def u_rho_T(rho, T, mat_id):
             A2_u_ANEOS_Fe85Si15,
             A1_log_rho_ANEOS_Fe85Si15,
             A1_log_T_ANEOS_Fe85Si15,
+        )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_u, A1_log_rho, A1_log_T = (
+            A2_u_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A1_log_T_ANEOS_pyrolite,
         )
     elif mat_id == gv.id_AQUA:
         A2_u, A1_log_rho, A1_log_T = (A2_u_AQUA, A1_log_rho_AQUA, A1_log_T_AQUA)
@@ -2668,6 +2769,12 @@ def s_u_rho(u, rho, mat_id):
             A2_s_ANEOS_Fe85Si15,
             A1_log_rho_ANEOS_Fe85Si15,
             A2_log_u_ANEOS_Fe85Si15,
+        )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_s, A1_log_rho, A2_log_u = (
+            A2_s_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A2_log_u_ANEOS_pyrolite,
         )
     elif mat_id == gv.id_AQUA:
         A2_s, A1_log_rho, A2_log_u = (A2_s_AQUA, A1_log_rho_AQUA, A2_log_u_AQUA)
@@ -2855,6 +2962,12 @@ def s_rho_T(rho, T, mat_id):
             A1_log_rho_ANEOS_Fe85Si15,
             A1_log_T_ANEOS_Fe85Si15,
         )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_s, A1_log_rho, A1_log_T = (
+            A2_s_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A1_log_T_ANEOS_pyrolite,
+        )
     elif mat_id == gv.id_AQUA:
         A2_s, A1_log_rho, A1_log_T = (A2_s_AQUA, A1_log_rho_AQUA, A1_log_T_AQUA)
     elif mat_id == gv.id_CMS19_H:
@@ -3038,6 +3151,12 @@ def rho_u_P(u, P, mat_id, rho_ref):
             A2_P_ANEOS_Fe85Si15,
             A1_log_rho_ANEOS_Fe85Si15,
             A2_log_u_ANEOS_Fe85Si15,
+        )
+    elif mat_id == gv.id_ANEOS_pyrolite:
+        A2_P, A1_log_rho, A2_log_u = (
+            A2_P_ANEOS_pyrolite,
+            A1_log_rho_ANEOS_pyrolite,
+            A2_log_u_ANEOS_pyrolite,
         )
     elif mat_id == gv.id_AQUA:
         A2_P, A1_log_rho, A2_log_u = (A2_P_AQUA, A1_log_rho_AQUA, A2_log_u_AQUA)

--- a/woma/misc/glob_vars.py
+++ b/woma/misc/glob_vars.py
@@ -51,6 +51,7 @@ Di_mat_id = {
     "ANEOS_forsterite": Di_mat_type["ANEOS"] * type_factor,  # Stewart et al. (2019)
     "ANEOS_iron": Di_mat_type["ANEOS"] * type_factor + 1,  # Stewart (2020)
     "ANEOS_Fe85Si15": Di_mat_type["ANEOS"] * type_factor + 2,  # Stewart (2020)
+    "ANEOS_pyrolite": Di_mat_type["ANEOS"] * type_factor + 3,  # Stewart (2022)
     # Mixed
     "mixed_HHe_heavy": Di_mat_type["mixed"] * type_factor,  # Vazan et al. (2013)
     "mixed_HHe_rock": Di_mat_type["mixed"] * type_factor + 1,
@@ -97,6 +98,7 @@ id_CD21_HHe = Di_mat_id["CD21_HHe"]
 id_ANEOS_forsterite = Di_mat_id["ANEOS_forsterite"]
 id_ANEOS_iron = Di_mat_id["ANEOS_iron"]
 id_ANEOS_Fe85Si15 = Di_mat_id["ANEOS_Fe85Si15"]
+id_ANEOS_pyrolite = Di_mat_id["ANEOS_pyrolite"]
 id_mixed_HHe_heavy = Di_mat_id["mixed_HHe_heavy"]
 id_mixed_HHe_rock = Di_mat_id["mixed_HHe_rock"]
 id_mixed_HHe_water = Di_mat_id["mixed_HHe_water"]
@@ -141,6 +143,7 @@ Fp_CD21_HHe = dir_data + "CD21_HHe.txt"
 Fp_ANEOS_forsterite = dir_data + "ANEOS_forsterite_S19.txt"
 Fp_ANEOS_iron = dir_data + "ANEOS_iron_S20.txt"
 Fp_ANEOS_Fe85Si15 = dir_data + "ANEOS_Fe85Si15_S20.txt"
+Fp_ANEOS_pyrolite = dir_data + "ANEOS_pyrolite_2022.txt"
 # Mixed tables
 Fp_mixed_HHe_rock = dir_data + "mixed_HHe_rock.hdf5"
 Fp_mixed_HHe_water = dir_data + "mixed_HHe_water.hdf5"

--- a/woma/misc/utils.py
+++ b/woma/misc/utils.py
@@ -627,6 +627,8 @@ def check_loaded_eos_tables():
         A1_mat.remove("ANEOS_iron")
     if len(eos.sesame.A1_rho_ANEOS_Fe85Si15) == 1:
         A1_mat.remove("ANEOS_Fe85Si15")
+    if len(eos.sesame.A1_rho_ANEOS_pyrolite) == 1:
+        A1_mat.remove("ANEOS_pyrolite")
 
     if len(eos.sesame.A1_rho_AQUA) == 1:
         A1_mat.remove("AQUA")
@@ -886,6 +888,21 @@ def load_eos_tables(A1_mat_input=None):
             eos.sesame.A2_log_c_ANEOS_Fe85Si15,
             eos.sesame.A2_log_s_ANEOS_Fe85Si15,
         ) = eos.sesame.load_table_SESAME(gv.Fp_ANEOS_Fe85Si15)
+    if "ANEOS_pyrolite" in A1_mat and len(eos.sesame.A1_rho_ANEOS_pyrolite) == 1:
+        (
+            eos.sesame.A1_rho_ANEOS_pyrolite,
+            eos.sesame.A1_T_ANEOS_pyrolite,
+            eos.sesame.A2_u_ANEOS_pyrolite,
+            eos.sesame.A2_P_ANEOS_pyrolite,
+            eos.sesame.A2_c_ANEOS_pyrolite,
+            eos.sesame.A2_s_ANEOS_pyrolite,
+            eos.sesame.A1_log_rho_ANEOS_pyrolite,
+            eos.sesame.A1_log_T_ANEOS_pyrolite,
+            eos.sesame.A2_log_u_ANEOS_pyrolite,
+            eos.sesame.A2_log_P_ANEOS_pyrolite,
+            eos.sesame.A2_log_c_ANEOS_pyrolite,
+            eos.sesame.A2_log_s_ANEOS_pyrolite,
+        ) = eos.sesame.load_table_SESAME(gv.Fp_ANEOS_pyrolite)
     if "AQUA" in A1_mat and len(eos.sesame.A1_rho_AQUA) == 1:
         (
             eos.sesame.A1_rho_AQUA,


### PR DESCRIPTION
## Summary
- Add the ANEOS pyrolite 2022 SESAME-style table as `ANEOS_pyrolite` with material ID `403`.
- Wire the table into the ANEOS EOS globals, loader, and interpolation branches.
- Document the table in the material list with a reference to Stewart's pyrolite repository: https://github.com/ststewart/aneos-pyrolite-2022

## Test
- `python3 -m py_compile woma/eos/sesame.py woma/misc/glob_vars.py woma/misc/utils.py`
- Imported WoMa from the checkout, loaded `ANEOS_pyrolite`, and verified ID `403` with grid shape `860 x 744`.
